### PR TITLE
fix: Add missing trail property to hostile particles

### DIFF
--- a/js/particle.js
+++ b/js/particle.js
@@ -74,7 +74,8 @@ export function createParticleExplosion(x, y, existingParticles) {
             size: 5,
             color: 'hsl(0, 100%, 70%)', // Bright red
             isHostile: true,
-            lifespan: 120 // 2 seconds at 60fps
+            lifespan: 120, // 2 seconds at 60fps
+            trail: []
         };
         newParticles.push(particle);
     }


### PR DESCRIPTION
This is a hotfix for a crash introduced in the previous commit.

The new 'particle explosion' attack created hostile particles without a `trail` property. The rendering engine requires this property to exist on all particles, and its absence was causing a `TypeError` that crashed the game loop.

This patch adds the `trail: []` property to hostile particles upon creation, resolving the crash.