### PR TITLE
chore: Add ESLint configuration for web editor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": "warn",
+    "no-undef": "warn"
+  }
+}


### PR DESCRIPTION
This commit adds a `.eslintrc.json` file to the project root.

This file configures the linter (used by tools like VS Code for the Web, which is opened by pressing '.' on GitHub) to understand a browser-based JavaScript module environment.

This will prevent the linter from showing a large number of false-positive errors (e.g., 'window is not defined') and provide a cleaner, more accurate editing experience for the user.