### PR TITLE
feat: Atualiza a cor de fundo da página inicial para roxo escuro

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ body {
     font-family: 'Arial', sans-serif;
     user-select: none;
     -webkit-tap-highlight-color: transparent; /* Adicionado */
-    background-color: #7d2ae7;
+    background-color: #10052A;
 }
 
 body.game-page {


### PR DESCRIPTION
Muda a cor de fundo da página inicial para #10052A, um roxo escuro, conforme especificado pelo usuário por meio de uma imagem.

Essa alteração alinha a identidade visual da tela inicial com a estética desejada para o jogo.